### PR TITLE
Add FreeBSD support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,25 @@ AC_SUBST(LT_CURRENT)
 AC_SUBST(LT_REVISION)
 AC_SUBST(LT_AGE)
 
+AC_CANONICAL_HOST
+
+target_os=""
+case $host_os in
+  linux*)
+        # do nothing
+        target_os="linux"
+        ;;
+   freebsd*)
+        target_os="freebsd"
+        ;;
+    *)
+        #Default Case
+        AC_MSG_ERROR([Your platform is not currently supported: $host_os])
+        ;;
+esac
+
+AM_CONDITIONAL([FREEBSD], [test "$target_os" = "freebsd"])
+
 AC_CONFIG_FILES([Makefile
                  etc/Makefile
                  plugins/Makefile

--- a/plugins/galax-raw.c
+++ b/plugins/galax-raw.c
@@ -29,7 +29,11 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+#ifdef __FreeBSD__
+#include <dev/evdev/input.h>
+#else
 #include <linux/input.h>
+#endif
 #ifndef EV_SYN /* 2.4 kernel headers */
 # define EV_SYN 0x00
 #endif

--- a/plugins/input-raw.c
+++ b/plugins/input-raw.c
@@ -28,7 +28,11 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+#ifdef __FreeBSD__
+#include <dev/evdev/input.h>
+#else
 #include <linux/input.h>
+#endif
 #ifndef EV_SYN /* 2.4 kernel headers */
 # define EV_SYN 0x00
 #endif

--- a/plugins/touchkit-raw.c
+++ b/plugins/touchkit-raw.c
@@ -46,7 +46,9 @@ static int touchkit_init(int dev)
 	tty.c_iflag = IGNBRK | IGNPAR;
 	tty.c_oflag = 0;
 	tty.c_lflag = 0;
+#ifdef __linux__
 	tty.c_line = 0;
+#endif
 	tty.c_cc[VTIME] = 0;
 	tty.c_cc[VMIN] = 1;
 	tty.c_cflag = CS8 | CREAD | CLOCAL | HUPCL;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,8 +13,13 @@ AM_CPPFLAGS		= -I$(top_srcdir)/src
 
 bin_PROGRAMS		= ts_test ts_calibrate ts_print ts_print_raw ts_harvest ts_finddev
 
-ts_test_SOURCES		= ts_test.c fbutils.c fbutils.h font_8x8.c font_8x16.c font.h
+ts_test_SOURCES		= ts_test.c fbutils.h font_8x8.c font_8x16.c font.h
 ts_test_LDADD		= $(top_builddir)/src/libts.la
+if FREEBSD
+ts_test_SOURCES		+= fbutils-bsd.c
+else
+ts_test_SOURCES		+= fbutils-linux.c
+endif
 
 ts_print_SOURCES	= ts_print.c
 ts_print_LDADD		= $(top_builddir)/src/libts.la
@@ -22,11 +27,21 @@ ts_print_LDADD		= $(top_builddir)/src/libts.la
 ts_print_raw_SOURCES	= ts_print_raw.c
 ts_print_raw_LDADD	= $(top_builddir)/src/libts.la
 
-ts_calibrate_SOURCES	= ts_calibrate.c fbutils.c fbutils.h testutils.c testutils.h font_8x8.c font_8x16.c font.h
+ts_calibrate_SOURCES	= ts_calibrate.c fbutils.h testutils.c testutils.h font_8x8.c font_8x16.c font.h
 ts_calibrate_LDADD	= $(top_builddir)/src/libts.la
+if FREEBSD
+ts_calibrate_SOURCES	+= fbutils-bsd.c
+else
+ts_calibrate_SOURCES	+= fbutils-linux.c
+endif
 
-ts_harvest_SOURCES	= ts_harvest.c fbutils.c fbutils.h testutils.c testutils.h font_8x8.c font_8x16.c font.h
+ts_harvest_SOURCES	= ts_harvest.c fbutils.h testutils.c testutils.h font_8x8.c font_8x16.c font.h
 ts_harvest_LDADD	= $(top_builddir)/src/libts.la
+if FREEBSD
+ts_harvest_SOURCES	+= fbutils-bsd.c
+else
+ts_harvest_SOURCES	+= fbutils-linux.c
+endif
 
 ts_finddev_SOURCES      = ts_finddev.c
 ts_finddev_LDADD        = $(top_builddir)/src/libts.la

--- a/tests/fbutils-bsd.c
+++ b/tests/fbutils-bsd.c
@@ -1,0 +1,331 @@
+/*
+ * fbutils.c
+ *
+ * Utility routines for framebuffer interaction
+ *
+ * Copyright 2002 Russell King and Doug Lowder
+ *
+ * This file is placed under the GPL.  Please see the
+ * file COPYING for details.
+ *
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+
+#include <sys/consio.h>
+#include <sys/fbio.h>
+
+#include "font.h"
+#include "fbutils.h"
+
+union multiptr {
+	unsigned char *p8;
+	unsigned short *p16;
+	unsigned long *p32;
+};
+
+static int fbsize;
+static unsigned char *fbuffer;
+static unsigned char **line_addr;
+static int fb_fd=0;
+static int bytes_per_pixel;
+static unsigned colormap [256];
+uint32_t xres, yres;
+
+static char *defaultfbdevice = "/dev/fb0";
+static char *fbdevice = NULL;
+
+int open_framebuffer(void)
+{
+	int y;
+	unsigned addr;
+	struct fbtype fb;
+	int line_length;
+
+	if ((fbdevice = getenv ("TSLIB_FBDEVICE")) == NULL)
+		fbdevice = defaultfbdevice;
+
+	fb_fd = open(fbdevice, O_RDWR);
+	if (fb_fd == -1) {
+		perror("open fbdevice");
+		return -1;
+	}
+
+
+	if (ioctl(fb_fd, FBIOGTYPE, &fb) != 0) {
+		perror("ioctl(FBIOGTYPE)");
+		return -1;
+	}
+
+	if (ioctl(fb_fd, FBIO_GETLINEWIDTH, &line_length) != 0) {
+		perror("ioctl(FBIO_GETLINEWIDTH)");
+		return -1;
+	}
+
+	xres = fb.fb_width;
+	yres = fb.fb_height;
+
+	int pagemask = getpagesize() - 1;
+	fbsize = ((int) line_length*yres + pagemask) & ~pagemask;
+
+	fbuffer = (unsigned char *)mmap(0, fbsize, PROT_READ | PROT_WRITE, MAP_SHARED, fb_fd, 0);
+	if (fbuffer == (unsigned char *)-1) {
+		perror("mmap framebuffer");
+		close(fb_fd);
+		return -1;
+	}
+	memset(fbuffer,0, fbsize);
+
+	bytes_per_pixel = (fb.fb_depth + 7) / 8;
+	line_addr = malloc (sizeof (uint32_t) * fb.fb_height);
+	addr = 0;
+	for (y = 0; y < fb.fb_height; y++, addr += line_length)
+		line_addr [y] = fbuffer + addr;
+
+	return 0;
+}
+
+void close_framebuffer(void)
+{
+	munmap(fbuffer, fbsize);
+	close(fb_fd);
+
+        free (line_addr);
+}
+
+void put_cross(int x, int y, unsigned colidx)
+{
+	fprintf(stderr, "%d %d, %d\n", x, y, colidx);
+
+	line (x - 10, y, x - 2, y, colidx);
+	line (x + 2, y, x + 10, y, colidx);
+	line (x, y - 10, x, y - 2, colidx);
+	line (x, y + 2, x, y + 10, colidx);
+
+#if 1
+	line (x - 6, y - 9, x - 9, y - 9, colidx + 1);
+	line (x - 9, y - 8, x - 9, y - 6, colidx + 1);
+	line (x - 9, y + 6, x - 9, y + 9, colidx + 1);
+	line (x - 8, y + 9, x - 6, y + 9, colidx + 1);
+	line (x + 6, y + 9, x + 9, y + 9, colidx + 1);
+	line (x + 9, y + 8, x + 9, y + 6, colidx + 1);
+	line (x + 9, y - 6, x + 9, y - 9, colidx + 1);
+	line (x + 8, y - 9, x + 6, y - 9, colidx + 1);
+#else
+	line (x - 7, y - 7, x - 4, y - 4, colidx + 1);
+	line (x - 7, y + 7, x - 4, y + 4, colidx + 1);
+	line (x + 4, y - 4, x + 7, y - 7, colidx + 1);
+	line (x + 4, y + 4, x + 7, y + 7, colidx + 1);
+#endif
+}
+
+void put_char(int x, int y, int c, int colidx)
+{
+	int i,j,bits;
+
+	for (i = 0; i < font_vga_8x8.height; i++) {
+		bits = font_vga_8x8.data [font_vga_8x8.height * c + i];
+		for (j = 0; j < font_vga_8x8.width; j++, bits <<= 1)
+			if (bits & 0x80)
+				pixel (x + j, y + i, colidx);
+	}
+}
+
+void put_string(int x, int y, char *s, unsigned colidx)
+{
+	int i;
+	for (i = 0; *s; i++, x += font_vga_8x8.width, s++)
+		put_char (x, y, *s, colidx);
+}
+
+void put_string_center(int x, int y, char *s, unsigned colidx)
+{
+	size_t sl = strlen (s);
+        put_string (x - (sl / 2) * font_vga_8x8.width,
+                    y - font_vga_8x8.height / 2, s, colidx);
+}
+
+void setcolor(unsigned colidx, unsigned value)
+{
+	unsigned res;
+	unsigned char red, green, blue;
+
+#ifdef DEBUG
+	if (colidx > 255) {
+		fprintf (stderr, "WARNING: color index = %u, must be <256\n",
+			 colidx);
+		return;
+	}
+#endif
+
+	red = (value >> 16) & 0xff;
+	green = (value >> 8) & 0xff;
+	blue = value & 0xff;
+
+	switch (bytes_per_pixel) {
+	case 1:
+		res = value;
+		break;
+	case 2:
+		res = ((red >> 3) << 11) | ((green >> 2) << 5) | (blue >> 3);
+		break;
+	case 3:
+	case 4:
+	default:
+		res = value;
+		
+	}
+        colormap [colidx] = res;
+}
+
+static inline void __setpixel (union multiptr loc, unsigned xormode, unsigned color)
+{
+	switch(bytes_per_pixel) {
+	case 1:
+	default:
+		if (xormode)
+			*loc.p8 ^= color;
+		else
+			*loc.p8 = color;
+		break;
+	case 2:
+		if (xormode)
+			*loc.p16 ^= color;
+		else
+			*loc.p16 = color;
+		break;
+	case 3:
+		if (xormode) {
+			*loc.p8++ ^= (color >> 16) & 0xff;
+			*loc.p8++ ^= (color >> 8) & 0xff;
+			*loc.p8 ^= color & 0xff;
+		} else {
+			*loc.p8++ = (color >> 16) & 0xff;
+			*loc.p8++ = (color >> 8) & 0xff;
+			*loc.p8 = color & 0xff;
+		}
+		break;
+	case 4:
+		if (xormode)
+			*loc.p32 ^= color;
+		else
+			*loc.p32 = color;
+		break;
+	}
+}
+
+void pixel (int x, int y, unsigned colidx)
+{
+	unsigned xormode;
+	union multiptr loc;
+
+	if ((x < 0) || ((uint32_t)x >= xres) ||
+	    (y < 0) || ((uint32_t)y >= yres))
+		return;
+
+	xormode = colidx & XORMODE;
+	colidx &= ~XORMODE;
+
+#ifdef DEBUG
+	if (colidx > 255) {
+		fprintf (stderr, "WARNING: color value = %u, must be <256\n",
+			 colidx);
+		return;
+	}
+#endif
+
+	loc.p8 = line_addr [y] + x * bytes_per_pixel;
+	__setpixel (loc, xormode, colormap [colidx]);
+}
+
+void line (int x1, int y1, int x2, int y2, unsigned colidx)
+{
+	int tmp;
+	int dx = x2 - x1;
+	int dy = y2 - y1;
+
+	if (abs (dx) < abs (dy)) {
+		if (y1 > y2) {
+			tmp = x1; x1 = x2; x2 = tmp;
+			tmp = y1; y1 = y2; y2 = tmp;
+			dx = -dx; dy = -dy;
+		}
+		x1 <<= 16;
+		/* dy is apriori >0 */
+		dx = (dx << 16) / dy;
+		while (y1 <= y2) {
+			pixel (x1 >> 16, y1, colidx);
+			x1 += dx;
+			y1++;
+		}
+	} else {
+		if (x1 > x2) {
+			tmp = x1; x1 = x2; x2 = tmp;
+			tmp = y1; y1 = y2; y2 = tmp;
+			dx = -dx; dy = -dy;
+		}
+		y1 <<= 16;
+		dy = dx ? (dy << 16) / dx : 0;
+		while (x1 <= x2) {
+			pixel (x1, y1 >> 16, colidx);
+			y1 += dy;
+			x1++;
+		}
+	}
+}
+
+void rect (int x1, int y1, int x2, int y2, unsigned colidx)
+{
+	line (x1, y1, x2, y1, colidx);
+	line (x2, y1, x2, y2, colidx);
+	line (x2, y2, x1, y2, colidx);
+	line (x1, y2, x1, y1, colidx);
+}
+
+void fillrect (int x1, int y1, int x2, int y2, unsigned colidx)
+{
+	int tmp;
+	unsigned xormode;
+	union multiptr loc;
+
+	/* Clipping and sanity checking */
+	if (x1 > x2) { tmp = x1; x1 = x2; x2 = tmp; }
+	if (y1 > y2) { tmp = y1; y1 = y2; y2 = tmp; }
+	if (x1 < 0) x1 = 0; if ((uint32_t)x1 >= xres) x1 = xres - 1;
+	if (x2 < 0) x2 = 0; if ((uint32_t)x2 >= xres) x2 = xres - 1;
+	if (y1 < 0) y1 = 0; if ((uint32_t)y1 >= yres) y1 = yres - 1;
+	if (y2 < 0) y2 = 0; if ((uint32_t)y2 >= yres) y2 = yres - 1;
+
+	if ((x1 > x2) || (y1 > y2))
+		return;
+
+	xormode = colidx & XORMODE;
+	colidx &= ~XORMODE;
+
+#ifdef DEBUG
+	if (colidx > 255) {
+		fprintf (stderr, "WARNING: color value = %u, must be <256\n",
+			 colidx);
+		return;
+	}
+#endif
+
+	colidx = colormap [colidx];
+
+	for (; y1 <= y2; y1++) {
+		loc.p8 = line_addr [y1] + x1 * bytes_per_pixel;
+		for (tmp = x1; tmp <= x2; tmp++) {
+			__setpixel (loc, xormode, colidx);
+			loc.p8 += bytes_per_pixel;
+		}
+	}
+}

--- a/tests/fbutils-linux.c
+++ b/tests/fbutils-linux.c
@@ -1,0 +1,405 @@
+/*
+ * fbutils.c
+ *
+ * Utility routines for framebuffer interaction
+ *
+ * Copyright 2002 Russell King and Doug Lowder
+ *
+ * This file is placed under the GPL.  Please see the
+ * file COPYING for details.
+ *
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+
+#include <linux/vt.h>
+#include <linux/kd.h>
+#include <linux/fb.h>
+
+#include "font.h"
+#include "fbutils.h"
+
+union multiptr {
+	unsigned char *p8;
+	unsigned short *p16;
+	unsigned long *p32;
+};
+
+static int con_fd, fb_fd, last_vt = -1;
+static struct fb_fix_screeninfo fix;
+static struct fb_var_screeninfo var;
+static unsigned char *fbuffer;
+static unsigned char **line_addr;
+static int fb_fd=0;
+static int bytes_per_pixel;
+static unsigned colormap [256];
+__u32 xres, yres;
+
+static char *defaultfbdevice = "/dev/fb0";
+static char *defaultconsoledevice = "/dev/tty";
+static char *fbdevice = NULL;
+static char *consoledevice = NULL;
+
+int open_framebuffer(void)
+{
+	struct vt_stat vts;
+	char vtname[128];
+	int fd, nr;
+	unsigned y, addr;
+
+	if ((fbdevice = getenv ("TSLIB_FBDEVICE")) == NULL)
+		fbdevice = defaultfbdevice;
+
+	if ((consoledevice = getenv ("TSLIB_CONSOLEDEVICE")) == NULL)
+		consoledevice = defaultconsoledevice;
+
+	if (strcmp (consoledevice, "none") != 0) {
+		sprintf (vtname,"%s%d", consoledevice, 1);
+        	fd = open (vtname, O_WRONLY);
+        	if (fd < 0) {
+        	        perror("open consoledevice");
+        	        return -1;
+        	}
+
+		if (ioctl(fd, VT_OPENQRY, &nr) < 0) {
+        	        perror("ioctl VT_OPENQRY");
+        	        return -1;
+        	}
+        	close(fd);
+
+        	sprintf(vtname, "%s%d", consoledevice, nr);
+
+        	con_fd = open(vtname, O_RDWR | O_NDELAY);
+        	if (con_fd < 0) {
+        	        perror("open tty");
+        	        return -1;
+        	}
+
+        	if (ioctl(con_fd, VT_GETSTATE, &vts) == 0)
+        	        last_vt = vts.v_active;
+
+        	if (ioctl(con_fd, VT_ACTIVATE, nr) < 0) {
+        	        perror("VT_ACTIVATE");
+        	        close(con_fd);
+        	        return -1;
+        	}
+
+#ifndef TSLIB_NO_VT_WAITACTIVE
+        	if (ioctl(con_fd, VT_WAITACTIVE, nr) < 0) {
+        	        perror("VT_WAITACTIVE");
+        	        close(con_fd);
+        	        return -1;
+        	}
+#endif
+
+        	if (ioctl(con_fd, KDSETMODE, KD_GRAPHICS) < 0) {
+        	        perror("KDSETMODE");
+        	        close(con_fd);
+        	        return -1;
+        	}
+
+	}
+
+	fb_fd = open(fbdevice, O_RDWR);
+	if (fb_fd == -1) {
+		perror("open fbdevice");
+		return -1;
+	}
+
+	if (ioctl(fb_fd, FBIOGET_FSCREENINFO, &fix) < 0) {
+		perror("ioctl FBIOGET_FSCREENINFO");
+		close(fb_fd);
+		return -1;
+	}
+
+	if (ioctl(fb_fd, FBIOGET_VSCREENINFO, &var) < 0) {
+		perror("ioctl FBIOGET_VSCREENINFO");
+		close(fb_fd);
+		return -1;
+	}
+	xres = var.xres;
+	yres = var.yres;
+
+	fbuffer = mmap(NULL, fix.smem_len, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fb_fd, 0);
+	if (fbuffer == (unsigned char *)-1) {
+		perror("mmap framebuffer");
+		close(fb_fd);
+		return -1;
+	}
+	memset(fbuffer,0,fix.smem_len);
+
+	bytes_per_pixel = (var.bits_per_pixel + 7) / 8;
+	line_addr = malloc (sizeof (__u32) * var.yres_virtual);
+	addr = 0;
+	for (y = 0; y < var.yres_virtual; y++, addr += fix.line_length)
+		line_addr [y] = fbuffer + addr;
+
+	return 0;
+}
+
+void close_framebuffer(void)
+{
+	munmap(fbuffer, fix.smem_len);
+	close(fb_fd);
+
+
+	if(strcmp(consoledevice,"none")!=0) {
+	
+        	if (ioctl(con_fd, KDSETMODE, KD_TEXT) < 0)
+        	        perror("KDSETMODE");
+
+        	if (last_vt >= 0)
+        	        if (ioctl(con_fd, VT_ACTIVATE, last_vt))
+        	                perror("VT_ACTIVATE");
+
+        	close(con_fd);
+	}
+
+        free (line_addr);
+}
+
+void put_cross(int x, int y, unsigned colidx)
+{
+	line (x - 10, y, x - 2, y, colidx);
+	line (x + 2, y, x + 10, y, colidx);
+	line (x, y - 10, x, y - 2, colidx);
+	line (x, y + 2, x, y + 10, colidx);
+
+#if 1
+	line (x - 6, y - 9, x - 9, y - 9, colidx + 1);
+	line (x - 9, y - 8, x - 9, y - 6, colidx + 1);
+	line (x - 9, y + 6, x - 9, y + 9, colidx + 1);
+	line (x - 8, y + 9, x - 6, y + 9, colidx + 1);
+	line (x + 6, y + 9, x + 9, y + 9, colidx + 1);
+	line (x + 9, y + 8, x + 9, y + 6, colidx + 1);
+	line (x + 9, y - 6, x + 9, y - 9, colidx + 1);
+	line (x + 8, y - 9, x + 6, y - 9, colidx + 1);
+#else
+	line (x - 7, y - 7, x - 4, y - 4, colidx + 1);
+	line (x - 7, y + 7, x - 4, y + 4, colidx + 1);
+	line (x + 4, y - 4, x + 7, y - 7, colidx + 1);
+	line (x + 4, y + 4, x + 7, y + 7, colidx + 1);
+#endif
+}
+
+void put_char(int x, int y, int c, int colidx)
+{
+	int i,j,bits;
+
+	for (i = 0; i < font_vga_8x8.height; i++) {
+		bits = font_vga_8x8.data [font_vga_8x8.height * c + i];
+		for (j = 0; j < font_vga_8x8.width; j++, bits <<= 1)
+			if (bits & 0x80)
+				pixel (x + j, y + i, colidx);
+	}
+}
+
+void put_string(int x, int y, char *s, unsigned colidx)
+{
+	int i;
+	for (i = 0; *s; i++, x += font_vga_8x8.width, s++)
+		put_char (x, y, *s, colidx);
+}
+
+void put_string_center(int x, int y, char *s, unsigned colidx)
+{
+	size_t sl = strlen (s);
+        put_string (x - (sl / 2) * font_vga_8x8.width,
+                    y - font_vga_8x8.height / 2, s, colidx);
+}
+
+void setcolor(unsigned colidx, unsigned value)
+{
+	unsigned res;
+	unsigned short red, green, blue;
+	struct fb_cmap cmap;
+
+#ifdef DEBUG
+	if (colidx > 255) {
+		fprintf (stderr, "WARNING: color index = %u, must be <256\n",
+			 colidx);
+		return;
+	}
+#endif
+
+	switch (bytes_per_pixel) {
+	default:
+	case 1:
+		res = colidx;
+		red = (value >> 8) & 0xff00;
+		green = value & 0xff00;
+		blue = (value << 8) & 0xff00;
+		cmap.start = colidx;
+		cmap.len = 1;
+		cmap.red = &red;
+		cmap.green = &green;
+		cmap.blue = &blue;
+		cmap.transp = NULL;
+
+        	if (ioctl (fb_fd, FBIOPUTCMAP, &cmap) < 0)
+        	        perror("ioctl FBIOPUTCMAP");
+		break;
+	case 2:
+	case 3:
+	case 4:
+		red = (value >> 16) & 0xff;
+		green = (value >> 8) & 0xff;
+		blue = value & 0xff;
+		res = ((red >> (8 - var.red.length)) << var.red.offset) |
+                      ((green >> (8 - var.green.length)) << var.green.offset) |
+                      ((blue >> (8 - var.blue.length)) << var.blue.offset);
+	}
+        colormap [colidx] = res;
+}
+
+static inline void __setpixel (union multiptr loc, unsigned xormode, unsigned color)
+{
+	switch(bytes_per_pixel) {
+	case 1:
+	default:
+		if (xormode)
+			*loc.p8 ^= color;
+		else
+			*loc.p8 = color;
+		break;
+	case 2:
+		if (xormode)
+			*loc.p16 ^= color;
+		else
+			*loc.p16 = color;
+		break;
+	case 3:
+		if (xormode) {
+			*loc.p8++ ^= (color >> 16) & 0xff;
+			*loc.p8++ ^= (color >> 8) & 0xff;
+			*loc.p8 ^= color & 0xff;
+		} else {
+			*loc.p8++ = (color >> 16) & 0xff;
+			*loc.p8++ = (color >> 8) & 0xff;
+			*loc.p8 = color & 0xff;
+		}
+		break;
+	case 4:
+		if (xormode)
+			*loc.p32 ^= color;
+		else
+			*loc.p32 = color;
+		break;
+	}
+}
+
+void pixel (int x, int y, unsigned colidx)
+{
+	unsigned xormode;
+	union multiptr loc;
+
+	if ((x < 0) || ((__u32)x >= var.xres_virtual) ||
+	    (y < 0) || ((__u32)y >= var.yres_virtual))
+		return;
+
+	xormode = colidx & XORMODE;
+	colidx &= ~XORMODE;
+
+#ifdef DEBUG
+	if (colidx > 255) {
+		fprintf (stderr, "WARNING: color value = %u, must be <256\n",
+			 colidx);
+		return;
+	}
+#endif
+
+	loc.p8 = line_addr [y] + x * bytes_per_pixel;
+	__setpixel (loc, xormode, colormap [colidx]);
+}
+
+void line (int x1, int y1, int x2, int y2, unsigned colidx)
+{
+	int tmp;
+	int dx = x2 - x1;
+	int dy = y2 - y1;
+
+	if (abs (dx) < abs (dy)) {
+		if (y1 > y2) {
+			tmp = x1; x1 = x2; x2 = tmp;
+			tmp = y1; y1 = y2; y2 = tmp;
+			dx = -dx; dy = -dy;
+		}
+		x1 <<= 16;
+		/* dy is apriori >0 */
+		dx = (dx << 16) / dy;
+		while (y1 <= y2) {
+			pixel (x1 >> 16, y1, colidx);
+			x1 += dx;
+			y1++;
+		}
+	} else {
+		if (x1 > x2) {
+			tmp = x1; x1 = x2; x2 = tmp;
+			tmp = y1; y1 = y2; y2 = tmp;
+			dx = -dx; dy = -dy;
+		}
+		y1 <<= 16;
+		dy = dx ? (dy << 16) / dx : 0;
+		while (x1 <= x2) {
+			pixel (x1, y1 >> 16, colidx);
+			y1 += dy;
+			x1++;
+		}
+	}
+}
+
+void rect (int x1, int y1, int x2, int y2, unsigned colidx)
+{
+	line (x1, y1, x2, y1, colidx);
+	line (x2, y1, x2, y2, colidx);
+	line (x2, y2, x1, y2, colidx);
+	line (x1, y2, x1, y1, colidx);
+}
+
+void fillrect (int x1, int y1, int x2, int y2, unsigned colidx)
+{
+	int tmp;
+	unsigned xormode;
+	union multiptr loc;
+
+	/* Clipping and sanity checking */
+	if (x1 > x2) { tmp = x1; x1 = x2; x2 = tmp; }
+	if (y1 > y2) { tmp = y1; y1 = y2; y2 = tmp; }
+	if (x1 < 0) x1 = 0; if ((__u32)x1 >= xres) x1 = xres - 1;
+	if (x2 < 0) x2 = 0; if ((__u32)x2 >= xres) x2 = xres - 1;
+	if (y1 < 0) y1 = 0; if ((__u32)y1 >= yres) y1 = yres - 1;
+	if (y2 < 0) y2 = 0; if ((__u32)y2 >= yres) y2 = yres - 1;
+
+	if ((x1 > x2) || (y1 > y2))
+		return;
+
+	xormode = colidx & XORMODE;
+	colidx &= ~XORMODE;
+
+#ifdef DEBUG
+	if (colidx > 255) {
+		fprintf (stderr, "WARNING: color value = %u, must be <256\n",
+			 colidx);
+		return;
+	}
+#endif
+
+	colidx = colormap [colidx];
+
+	for (; y1 <= y2; y1++) {
+		loc.p8 = line_addr [y1] + x1 * bytes_per_pixel;
+		for (tmp = x1; tmp <= x2; tmp++) {
+			__setpixel (loc, xormode, colidx);
+			loc.p8 += bytes_per_pixel;
+		}
+	}
+}

--- a/tests/fbutils.h
+++ b/tests/fbutils.h
@@ -13,7 +13,12 @@
 #ifndef _FBUTILS_H
 #define _FBUTILS_H
 
+#ifdef __FreeBSD__
+#include <sys/stdint.h>
+typedef uint32_t __u32;
+#else
 #include <asm/types.h>
+#endif
 
 /* This constant, being ORed with the color index tells the library
  * to draw in exclusive-or mode (that is, drawing the same second time

--- a/tests/font.h
+++ b/tests/font.h
@@ -11,8 +11,6 @@
 #ifndef _VIDEO_FONT_H
 #define _VIDEO_FONT_H
 
-#include <linux/types.h>
-
 struct fbcon_font_desc {
     int idx;
     char *name;

--- a/tests/ts_calibrate.c
+++ b/tests/ts_calibrate.c
@@ -21,9 +21,6 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <sys/stat.h>
-#include <linux/kd.h>
-#include <linux/vt.h>
-#include <linux/fb.h>
 
 #include "tslib.h"
 

--- a/tests/ts_print.c
+++ b/tests/ts_print.c
@@ -16,6 +16,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 #include "tslib.h"
 
@@ -56,7 +57,8 @@ int main()
 		if (ret != 1)
 			continue;
 
-		printf("%ld.%06ld: %6d %6d %6d\n", samp.tv.tv_sec, samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
+		printf("%jd.%06jd: %6d %6d %6d\n", (intmax_t)samp.tv.tv_sec,
+			(intmax_t)samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
 
 	}
 }

--- a/tests/ts_print_raw.c
+++ b/tests/ts_print_raw.c
@@ -16,6 +16,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 #include "tslib.h"
 
@@ -56,7 +57,8 @@ int main()
 		if (ret != 1)
 			continue;
 
-		printf("%ld.%06ld: %6d %6d %6d\n", samp.tv.tv_sec, samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
+		printf("%jd.%06jd: %6d %6d %6d\n", (intmax_t)samp.tv.tv_sec,
+			(intmax_t)samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
 
 	}
 }

--- a/tests/ts_test.c
+++ b/tests/ts_test.c
@@ -19,6 +19,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 #include "tslib.h"
 #include "fbutils.h"
@@ -199,8 +200,8 @@ int main()
 					quit_pressed = 1;
 				}
 
-		printf("%ld.%06ld: %6d %6d %6d\n", samp.tv.tv_sec, samp.tv.tv_usec,
-			samp.x, samp.y, samp.pressure);
+		printf("%jd.%06jd: %6d %6d %6d\n", (intmax_t)samp.tv.tv_sec,
+			(intmax_t)samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
 
 		if (samp.pressure > 0) {
 			if (mode == 0x80000001)


### PR DESCRIPTION
evdev support has been added to FreeBSD recently, so tslib now can be used there. This pull requests contains following changes:
- Add fbutils support for FreeBSD framebuffer
- Add autoconf conditional to switch between fbutils implementations
- Remove explicit -ldl for tsllib, it's handled by libtool/autoconf
- Make path to input.h header depend on target OS
- Access c_line field of struct termios only on Linux
- Remove unused includes from several files
- Make printing struct timeval cross-platform

input-raw plugin and executables were tested on both Linux and FreeBSD and found no regression. 
Unfortunately I don't have hardware to test galaxy-raw and touchkit-raw plugins. 
