### PR TITLE
tests/ts_calibrate: add missing headers

### DIFF
--- a/tests/ts_calibrate.c
+++ b/tests/ts_calibrate.c
@@ -17,6 +17,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #ifdef __ANDROID__
 #include <fcntl.h>


### PR DESCRIPTION
The open(2) system call requires sys/types.h and sys/stat.h. Fix the following
build failure under uClibc-ng:

ts_calibrate.c: In function ‘main’:
ts_calibrate.c:248:19: error: ‘S_IRUSR’ undeclared (first use in this function)
                   S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
                   ^