### PR TITLE
Update fbutils-linux.c to fix fillrect only drawing first y line

### DIFF
--- a/tests/fbutils-bsd.c
+++ b/tests/fbutils-bsd.c
@@ -353,7 +353,7 @@ void fillrect (int x1, int y1, int x2, int y2, unsigned colidx)
 
 	for (; y1 <= y2; y1++) {
 		for (tmp = x1; tmp <= x2; tmp++) {
-			__pixel_loc(x1, y1, &loc);
+			__pixel_loc(tmp, y1, &loc);
 			__setpixel (loc, xormode, colidx);
 			loc.p8 += bytes_per_pixel;
 		}

--- a/tests/fbutils-linux.c
+++ b/tests/fbutils-linux.c
@@ -457,7 +457,7 @@ void fillrect (int32_t x1, int32_t y1, int32_t x2, int32_t y2, uint32_t colidx)
 
 	for (; y1 <= y2; y1++) {
 		for (tmp = x1; tmp <= x2; tmp++) {
-			__pixel_loc(x1, y1, &loc);
+			__pixel_loc(tmp, y1, &loc);
 			__setpixel(loc, xormode, colidx);
 			loc.p8 += bytes_per_pixel;
 		}


### PR DESCRIPTION
Update fbutils-linux.c because fillrect only draw y0 line caused by a wrong parameter in __pixel_loc.